### PR TITLE
Add a simple stack.yaml file.  Builds but fails tests.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,10 @@
+flags:
+  packman:
+    debug: false
+packages:
+- '.'
+extra-deps: []
+resolver: lts-2.22
+
+#docker:
+#  enable: true


### PR DESCRIPTION
Very small tweak -- just adds a stack.yaml file to document what the suggested version of GHC, and make it build with a single `stack build` command.  (Even if that means installing a new GHC.)

For details, please see:

  https://gist.github.com/rrnewton/5f8b1db0a3f264ab48b7