### PR TITLE
Wip/fixtests

### DIFF
--- a/packman.cabal
+++ b/packman.cabal
@@ -13,7 +13,7 @@ license-file:        LICENSE
 author:              Michael Budde, Ásbjørn V. Jøkladal, Jost Berthold
 maintainer:          jb.diku@gmail.com
 build-type:          Simple
-cabal-version:       >= 1.18
+cabal-version:       >= 1.20
 tested-with:         GHC==7.8.2, GHC==7.8.3, GHC==7.10.2
 extra-source-files:  cbits/Wrapper.cmm
                      cbits/Pack.c
@@ -95,7 +95,7 @@ test-suite alltests
                      binary >= 0.7,
                      bytestring >= 0.10,
                      primitive >= 0.5,
-                     Cabal >= 1.18,
+                     Cabal >= 1.20,
                      packman
   default-language:  Haskell2010
   if flag(debug)
@@ -112,7 +112,7 @@ test-suite testmthread
                      binary >= 0.7,
                      bytestring >= 0.10,
                      primitive >= 0.5,
-                     Cabal >= 1.18,
+                     Cabal >= 1.20,
                      packman
   default-language:  Haskell2010
   if flag(debug)
@@ -131,7 +131,7 @@ test-suite quickchecktest
                      binary >= 0.7,
                      bytestring >= 0.10,
                      primitive >= 0.5,
-                     Cabal >= 1.18,
+                     Cabal >= 1.20,
                      QuickCheck >= 2.6,
                      packman
   default-language:  Haskell2010

--- a/packman.cabal
+++ b/packman.cabal
@@ -33,7 +33,6 @@ library
                      GHC.Packing.Type
                      GHC.Packing.Core
   build-depends:     base >= 4.7 && < 5,
-                     ghc >= 7.8,
                      ghc-prim >= 0.3,
                      array >= 0.5,
                      binary >= 0.7,
@@ -45,6 +44,7 @@ library
   c-sources:         cbits/Wrapper.cmm
                      cbits/Pack.c
   include-dirs:      cbits
+  includes:
   default-language:  Haskell2010
   if flag(debug)
     cc-options:      -g -DDEBUG -DLIBRARY_CODE


### PR DESCRIPTION
removes unnecessary req.ment ghc (library),
in turn requiring Cabal >= 1.20 which supports detailed-0.9 tests properly 