### PR TITLE
lower cabal dependency for building again: 1.18

### DIFF
--- a/packman.cabal
+++ b/packman.cabal
@@ -48,7 +48,7 @@ license-file:        LICENSE
 author:              Michael Budde, Ásbjørn V. Jøkladal, Jost Berthold
 maintainer:          jost.berthold@gmail.com
 build-type:          Simple
-cabal-version:       >= 1.20
+cabal-version:       >= 1.18
 tested-with:         GHC==7.8.2, GHC==7.8.3, GHC==7.10.2
 extra-source-files:  cbits/Wrapper.cmm
                      cbits/Pack.c


### PR DESCRIPTION
... while keeping the testing requirements (partially) at 1.20

I do not see the point to exclude Cabal-1.18 from building (which is kind of annoying with the stackage package lists) - specifying this requirement for the affected tests should be enough.