### PR TITLE
Build and test in GitHub CI

### DIFF
--- a/.github/workflows/bash.nix
+++ b/.github/workflows/bash.nix
@@ -1,0 +1,4 @@
+import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/4ecab3273592f27479a583fb6d975d4aba3486fe.tar.gz";
+  sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+}) {}

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
-        cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
+        cc: [gcc8, gcc14, clang_12, clang_18]
         exclude:
           # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580) so we exlude these
           - os: macos-13

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -1,0 +1,85 @@
+name: Build & test in nix-shell
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
+        ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
+        cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
+        exclude:
+          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580) so we exlude these
+          - os: macos-13
+            ghc: ghc7103
+          - os: macos-13
+            ghc: ghc802
+          - os: macos-13
+            ghc: ghc822
+          - os: macos-13
+            ghc: ghc844
+          - os: macos-14
+            ghc: ghc7103
+          - os: macos-14
+            ghc: ghc802
+          - os: macos-14
+            ghc: ghc822
+          - os: macos-14
+            ghc: ghc844
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.20.5/install
+          # NOTE: We avoid using arm64 builds of GHC (because they're mostly broken for early GHC versions) by specifying 'system = x86_64-darwin' for macOS runners
+          extra_nix_config: |
+            substituters = https://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            system-features = benchmark big-parallel kvm nixos-test
+            ${{ startsWith(matrix.os, 'macos') && 'system = x86_64-darwin' || '' }}
+
+      - name: Cache cabal files
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}--${{ matrix.ghc }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os }}-
+
+      # Make nix-shell use specific Bash version.
+      # Cf. https://nixos.org/manual/nix/stable/command-ref/nix-shell#environment-variables.
+      - name: Set shell Bash
+        run: echo "NIX_BUILD_SHELL=$(nix-build -A bash .github/workflows/bash.nix)/bin/bash" >> $GITHUB_ENV
+
+      - name: Test nix-shell # test that the Nix shell actually works
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
+
+      - name: Export GHC version env var
+        run: echo "GHC_VERSION=$(nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'ghc --numeric-version')" >> $GITHUB_ENV
+
+      - name: Run 'cabal update'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal update'
+
+      - name: Build library
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal build lib:packman'
+
+      - name: Build tests
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal build --enable-tests'
+
+      - name: Run tests
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal
+
+      # Run all tests again showing only the output of failed tests
+      - name: Run failed tests
+        if: failure()
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal test --test-show-details failures'

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -10,26 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
-        ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
+        ghc: [ghc865Binary, ghc884, ghc810]
         cc: [gcc8, gcc14, clang_12, clang_18]
-        exclude:
-          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580) so we exlude these
-          - os: macos-13
-            ghc: ghc7103
-          - os: macos-13
-            ghc: ghc802
-          - os: macos-13
-            ghc: ghc822
-          - os: macos-13
-            ghc: ghc844
-          - os: macos-14
-            ghc: ghc7103
-          - os: macos-14
-            ghc: ghc802
-          - os: macos-14
-            ghc: ghc822
-          - os: macos-14
-            ghc: ghc844
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,33 @@
+{ ghcVersion ? "ghc90"
+, ccVersion ? "gcc9"
+} :
+let
+  pkgs =
+    import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/4ecab3273592f27479a583fb6d975d4aba3486fe.tar.gz";
+      sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+    }) {};
+
+  pkgs1809 =
+    import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/925ff360bc33876fdb6ff967470e34ff375ce65e.tar.gz";
+      sha256 = "1qbmp6x01ika4kdc7bhqawasnpmhyl857ldz25nmq9fsmqm1vl2s";
+    }) {};
+
+  pkgs2405 =
+    import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/31ac92f9628682b294026f0860e14587a09ffb4b.tar.gz";
+      sha256 = "0qbyywfgjljfb4izdngxvbyvbrkilmpsmmx2a9spbwir2bcmbi14";
+    }) {};
+
+  ghc = pkgs.haskell.compiler.${ghcVersion} or pkgs1809.haskell.compiler.${ghcVersion};
+in
+pkgs.mkShell {
+  nativeBuildInputs = [
+    ghc
+    pkgs.cabal-install
+    pkgs.git
+    pkgs2405.${ccVersion}
+  ];
+}
+


### PR DESCRIPTION
@jberthold thank you for creating this package. I wanted to understand which GHC versions and C compiler versions it works with, so I created a GitHub CI config that builds for multiple versions of each — both for Linux and macOS.

The result of running this CI workflow can be seen in my fork of this repo: https://github.com/runeksvendsen/packman/pull/1 (the same PR but targeting the master branch of my fork).

It reveals a couple of bugs:
1. https://github.com/jberthold/packman/issues/18
2. https://github.com/jberthold/packman/issues/20

Where #20 is rather easy to fix (https://github.com/runeksvendsen/packman/pull/2/commits/a42fb0e93b623c524fc1c77fe8ea40c314909717), but the issue behind #18 is not immediately clear to me.

Note: commit https://github.com/jberthold/packman/pull/19/commits/dfc0f583f3d470a18934e6d6e666e86f6c4f412f in this PR tests a total of 216 combinations of different operating systems, GHC and C compilers. This has the advantage that it covers a lot of different configurations, but the disadvantage that it's difficult to quickly get an overview of why a given CI run, that has *N* number of failures, actually failed — e.g. is it the same failure happening multiple times or different errors? For this reason, one could consider reducing the number of different configurations.

## TODO

- [ ] Enable testing on ARM macOS once https://github.com/jberthold/packman/pull/22 is merged