### PR TITLE
Fix #20

### DIFF
--- a/Test/AllTests.hs
+++ b/Test/AllTests.hs
@@ -1,17 +1,19 @@
 {-
   Some tests to verify that serialisation works as expected
 -}
-module AllTests(tests)
+module Main(main)
     where
 
 import GHC.Packing
 
 import qualified Data.Array.IArray as A
 import Control.Concurrent
+import Control.Monad (forM_, forM, unless)
 
 import System.Environment
 import System.IO
 import System.Directory
+import qualified System.Exit
 import qualified Data.ByteString as B
 import Control.Exception
 import Data.Typeable
@@ -51,6 +53,20 @@ tests = do putStrLn "Running all tests"
 
 -- all configured tests, see below
 mytests = [eval_array, pack_array, pack_ThreadId, pack_MVar ]
+
+main :: IO ()
+main = do
+    putStrLn "Running all tests"
+    results <- forM mytests runTest
+    unless (and results) $ do
+        putStrLn "Some tests failed (see output above)"
+        System.Exit.exitFailure
+    where
+        runTest (name, action) = do
+            putStrLn $ "Running test '" ++ name ++ "'..."
+            b <- action
+            putStrLn $ (if b then "PASS: " else "FAIL: ") ++ name
+            return b
 
 -- test data
 arr, output :: A.Array Int Int

--- a/packman.cabal
+++ b/packman.cabal
@@ -123,8 +123,8 @@ test-suite testexceptions
     ghc-options:     -debug -optc-g -optc-DDEBUG
 
 test-suite alltests
-  type:              detailed-0.9
-  test-module:       AllTests
+  type:              exitcode-stdio-1.0
+  main-is:           AllTests.hs
   hs-source-dirs:    Test
   build-depends:     base >= 4.7,
                      directory >= 1.2,
@@ -159,8 +159,8 @@ test-suite testmthread
     ghc-options:     -with-rtsopts=-N4 -threaded
 
 test-suite quickchecktest
-  type:              detailed-0.9
-  test-module:       QCTest
+  type:              exitcode-stdio-1.0
+  main-is:           QCTest.hs
   hs-source-dirs:    Test
   build-depends:     base >= 4.7,
                      directory >= 1.2,


### PR DESCRIPTION
Fixes #20 by changing the type of the two test suites `alltests` and `quickchecktest` from `detailed-0.9` to `exitcode-stdio-1.0`.
