### PR TITLE
`aarch64` support

### DIFF
--- a/GHC/Packing/Type.hs
+++ b/GHC/Packing/Type.hs
@@ -280,7 +280,7 @@ prgHash = unsafePerformIO $
 -- removed. This code here is a cheap and incomplete hack, as the
 -- package would otherwise need a configure script.
 
-#if x86_64_BUILD_ARCH
+#if x86_64_BUILD_ARCH || aarch64_BUILD_ARCH
 type TargetWord = Word64
 hexWordFmt = "0x%016x"
 #elif i386_BUILD_ARCH


### PR DESCRIPTION
Building on macOS ARM was failing with the error below. The change in question makes `packman` build on ARM and all the test suites pass.

```
GHC/Packing/Type.hs:292:2: error:
     warning: Don't know the word size on your machine. [-W#warnings]
    |
292 | #warning Don't know the word size on your machine.
    |  ^
#warning Don't know the word size on your machine.
 ^
1 warning generated.
[2 of 4] Compiling GHC.Packing.Type ( GHC/Packing/Type.hs, /Users/runner/work/packman/packman/dist-newstyle/build/aarch64-osx/ghc-8.10.7/packman-0.5.1/build/GHC/Packing/Type.o, /Users/runner/work/packman/packman/dist-newstyle/build/aarch64-osx/ghc-8.10.7/packman-0.5.1/build/GHC/Packing/Type.dyn_o )

GHC/Packing/Type.hs:115:34: error:
    Variable not in scope: hexWordFmt :: [Char]
    |
115 |                     printf ('\t':hexWordFmt) w
    |                                  ^^^^^^^^^^
```