### PR TITLE
CI: enable ARM

### DIFF
--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -18,6 +18,9 @@ jobs:
             ghc: ghc884
           - os: macos-14
             ghc: ghc865Binary
+          # The macOS ARM builds of GCC, as provided by nixpkgs via shell.nix, are broken for GCC < 11. So we exclude GCC 8.
+          - os: macos-14
+            cc: gcc8
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -12,6 +12,12 @@ jobs:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
         ghc: [ghc865Binary, ghc884, ghc810]
         cc: [gcc8, gcc14, clang_12, clang_18]
+        exclude:
+          # The macOS ARM builds of GHC, as provided by nixpkgs via shell.nix, are broken for GHC < 8.10. So we exclude them for the ARM macOS runner (macos-14).
+          - os: macos-14
+            ghc: ghc884
+          - os: macos-14
+            ghc: ghc865Binary
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -21,12 +27,10 @@ jobs:
         uses: cachix/install-nix-action@v25
         with:
           install_url: https://releases.nixos.org/nix/nix-2.20.5/install
-          # NOTE: We avoid using arm64 builds of GHC (because they're mostly broken for early GHC versions) by specifying 'system = x86_64-darwin' for macOS runners
           extra_nix_config: |
             substituters = https://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             system-features = benchmark big-parallel kvm nixos-test
-            ${{ startsWith(matrix.os, 'macos') && 'system = x86_64-darwin' || '' }}
 
       - name: Cache cabal files
         uses: actions/cache@v3


### PR DESCRIPTION
The macos-14 runner uses the Apple M1 chip ARM chip (aarch64 architecture). ARM was previously not used for this runner by appending `system = x86_64-darwin` to the Nix config. Removing this from the Nix config enables ARM in CI. However, we also need to exclude ARM GHC versions before 8.10 since they're broken in nixpkgs (which provides GHC to us via shell.nix).

## TODO

- [x] GCC < 11 is broken for aarch64-darwin in nixpkgs 24.05