### PR TITLE
CI: Run "Run failed tests"-step only if "Run tests"-step failed

### DIFF
--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -59,9 +59,10 @@ jobs:
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal build --enable-tests'
 
       - name: Run tests
+        id: run_tests
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal
 
-      # Run all tests again showing only the output of failed tests
+      # Run all tests again if the "Run tests"-step failed, showing only the output of failed tests
       - name: Run failed tests
-        if: failure()
+        if: ${{ failure() && steps.run_tests.conclusion == 'failure' }}
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal test --test-show-details failures'


### PR DESCRIPTION
The old behavior was to run the "Run failed tests"-step in case of failure of _any_ previous step. But this is unnecessary if a step other than the "Run tests"-step failed, and also confusing to look at when viewing a failed CI job (since the output of the "Run failed tests"-step is not relevant unless it was the "Run tests"-step that failed).