### PR TITLE
CI: don't share cache between C compilers

### DIFF
--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -42,8 +42,8 @@ jobs:
             ~/.cabal/packages
             ~/.cabal/store
             dist-newstyle
-          key: ${{ runner.os }}-${{ matrix.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}--${{ matrix.ghc }}
-          restore-keys: ${{ runner.os }}-${{ matrix.os }}-
+          key: ${{ runner.os }}-${{ matrix.os }}-${{ matrix.ghc }}-${{ matrix.cc }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os }}-${{ matrix.ghc }}-${{ matrix.cc }}-
 
       # Make nix-shell use specific Bash version.
       # Cf. https://nixos.org/manual/nix/stable/command-ref/nix-shell#environment-variables.


### PR DESCRIPTION
The "Cache cabal files"-step would restore a cache from a key that does not include the C compiler, which means a job using e.g. Clang as the C compiler could restore stuff built using GCC.

Also, the `restore-keys` key didn't even include the GHC version. This meant that -- in case of a cache miss for `key` -- a cache built by one GHC version could be pulled for a CI run for another GHC version.